### PR TITLE
feat(keymap): add `desc` helper function to keymap mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ In cosynvim there are some apis that make it easy to set keymap. All apis are de
 keymap.(n/i/c/v/x/t)map -- function to generate keymap by vim.keymap.set
 keymap.new_opts -- generate opts into vim.keymap.set
 -- function type that work with keymap.new_opts
-keymap.silent keymap.noremap keymap.expr keymap.nowait keymap.remap
+keymap.silent keymap.noremap keymap.expr keymap.nowait keymap.remap keymap.desc('Some description')
 keymap.cmd -- just return string with <Cmd> and <CR>
 keymap.cu -- work like cmd but for visual map
 ```
@@ -195,7 +195,7 @@ confused what is `<cmd>` check `:h <cmd>` you will get answer
 
 ```lua
   -- window jump
-  {"<C-h>",'<C-w>h',opts(noremap)},
+  {"<C-h>",'<C-w>h',opts(noremap, desc 'Goto left window')},
 ```
 
 also you can pass a table not include sub table to `map` like

--- a/lua/core/keymap.lua
+++ b/lua/core/keymap.lua
@@ -50,6 +50,14 @@ function keymap.nowait(opt)
   end
 end
 
+function keymap.desc(desc)
+  return function(opt)
+    return function()
+      opt.desc = desc
+    end
+  end
+end
+
 function keymap.new_opts(...)
   local args = { ... }
   local o = opts:new()


### PR DESCRIPTION
Vim's keymap `desc` option is very useful, so I added the `desc` helper function to the keymap mod.
Hope to merge.