### PR TITLE
Update some small details

### DIFF
--- a/bin/dope
+++ b/bin/dope
@@ -57,8 +57,8 @@ if argument == 'help' then
   local helper = require('core.helper')
   helper.green('Dope usage')
   local usage = {
-    { '\tInstall', '  Install Plugins' },
-    { '\tUpdate ', '  Update Plugins' },
+    { '\tinstall', '  Install Plugins' },
+    { '\tupdate ', '  Update Plugins' },
     { '\tclean  ', '  clean the direcotries' },
     { '\tdoctor ', '  check the plugins info' },
     { '\tmodules', '  Show all modules' },

--- a/lua/keymap/init.lua
+++ b/lua/keymap/init.lua
@@ -42,10 +42,9 @@ imap({
 cmap({ '<C-b>', '<Left>', opts(noremap) })
 -- usage of plugins
 nmap({
-  -- packer
-  { '<Leader>pu', cmd('PackerUpdate'), opts(noremap, silent) },
-  { '<Leader>pi', cmd('PackerInstall'), opts(noremap, silent) },
-  { '<Leader>pc', cmd('PackerCompile'), opts(noremap, silent) },
+  -- plugin manager: Lazy.nvim
+  { '<Leader>pu', cmd('Lazy update'), opts(noremap, silent) },
+  { '<Leader>pi', cmd('Lazy install'), opts(noremap, silent) },
   -- dashboard
   { '<Leader>n', cmd('DashboardNewFile'), opts(noremap, silent) },
   { '<Leader>ss', cmd('SessionSave'), opts(noremap, silent) },


### PR DESCRIPTION
After swithing to lazy, plugins management commands in keymap configuration have not been updated, 

`install` & `update` hint come from dope cli command `help` is case mismatch

so I update some small details in it